### PR TITLE
feat: senpy spectral-index — per-source α from a measure catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,21 @@ For example M87 comes out at **≈138 Jy integrated in NVSS** — matching its
 catalogued 1.4 GHz flux — and lower in FIRST, whose finer beam resolves out the
 extended emission.
 
+### Spectral index — fit α per source
+
+`measure` and `spectral-index` compose: measure once, then fit a power law
+(_S ∝ ν<sup>α</sup>_) across each source's radio bands. Two bands give the exact
+index; three or more give a least-squares SED slope with an uncertainty.
+
+```bash
+senpy measure         targets.csv catalog.csv -s TGSS,NVSS,VLASS
+senpy spectral-index  catalog.csv alpha.csv     # -> source, n_bands, alpha, alpha_err
+```
+
+On bright calibrators this cleanly separates flat-spectrum cores (3C84, 3C273;
+α ≈ −0.3) from steep-spectrum sources (3C196 α ≈ −0.80, matching its catalogued
+value).
+
 ### Python API
 
 ```python

--- a/cirada_senpy/cli/commands.py
+++ b/cirada_senpy/cli/commands.py
@@ -1,4 +1,8 @@
-from cirada_senpy.core import download_file, measure_catalog
+from cirada_senpy.core import (
+    download_file,
+    measure_catalog,
+    spectral_index_from_catalog,
+)
 from cirada_senpy.core.surveys import AVAILABLE_SURVEYS, DEFAULT_SURVEYS
 
 import click
@@ -67,6 +71,22 @@ def measure(input_path: str, output_path: str, surveys: str, radius: float):
         surveys=survey_list,
         radius_arcmin=radius,
     )
+
+
+@cli.command("spectral-index")
+@click.argument("catalog_path", type=str)
+@click.argument("output_path", type=str)
+@click.option(
+    "--flux",
+    "-f",
+    "flux_column",
+    default="integrated",
+    type=click.Choice(["integrated", "peak"]),
+    help="Flux measure to fit (falls back to peak where missing).",
+)
+def spectral_index_cmd(catalog_path: str, output_path: str, flux_column: str):
+    """Fit a per-source radio spectral index from a `senpy measure` catalog."""
+    spectral_index_from_catalog(catalog_path, output_path, flux_column=flux_column)
 
 
 if __name__ == "__main__":

--- a/cirada_senpy/core/__init__.py
+++ b/cirada_senpy/core/__init__.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 
 from .catalog import measure_catalog
 from .handler import Handler
+from .sed import spectral_index_from_catalog
 from .surveys import AVAILABLE_SURVEYS, DEFAULT_SURVEYS
 from .utils import open_fits_tgz
 
@@ -27,6 +28,7 @@ __all__ = [
     "Handler",
     "download_file",
     "measure_catalog",
+    "spectral_index_from_catalog",
     "open_fits_tgz",
     "AVAILABLE_SURVEYS",
     "DEFAULT_SURVEYS",

--- a/cirada_senpy/core/sed.py
+++ b/cirada_senpy/core/sed.py
@@ -1,0 +1,55 @@
+"""Per-source spectral index from a measurement catalog (S ∝ ν**α)."""
+from typing import Optional, Union
+
+import pandas as pd
+
+from ..io.data_file import read_file, write_file
+from ..science import SURVEY_FREQUENCY_MHZ, fit_spectral_index
+
+
+def spectral_index_from_catalog(
+    catalog: Union[str, pd.DataFrame],
+    output_path: Optional[str] = None,
+    flux_column: str = "integrated",
+) -> pd.DataFrame:
+    """Fit a power-law spectral index per source from a ``senpy measure`` catalog.
+
+    Uses ``flux_column`` (default ``integrated``), falling back to ``peak`` where
+    it is missing. Only radio surveys with a known frequency contribute; VLASS
+    tiles are collapsed to one flux per survey (the brightest). Returns a
+    per-source DataFrame: ``source, ra, dec, n_bands, alpha, alpha_err``.
+    """
+    data = read_file(catalog) if isinstance(catalog, str) else catalog.copy()
+    data = data[data["survey"].isin(SURVEY_FREQUENCY_MHZ)].copy()
+    data["freq"] = data["survey"].map(SURVEY_FREQUENCY_MHZ)
+    data["flux"] = data[flux_column].where(data[flux_column].notna(), data["peak"])
+
+    # One flux per (source, survey): the brightest tile.
+    per_band = (
+        data.groupby(["source", "survey"])
+        .agg(ra=("ra", "first"), dec=("dec", "first"),
+             freq=("freq", "first"), flux=("flux", "max"))
+        .reset_index()
+    )
+
+    rows = []
+    for source, group in per_band.groupby("source"):
+        alpha, alpha_err = fit_spectral_index(group["freq"].values, group["flux"].values)
+        rows.append(
+            {
+                "source": source,
+                "ra": group["ra"].iloc[0],
+                "dec": group["dec"].iloc[0],
+                "n_bands": int((group["flux"] > 0).sum()),
+                "alpha": alpha,
+                "alpha_err": alpha_err,
+            }
+        )
+    result = pd.DataFrame(
+        rows, columns=["source", "ra", "dec", "n_bands", "alpha", "alpha_err"]
+    )
+    if output_path:
+        write_file(result, output_path)
+    print(f"\nFitted spectral index for {len(result)} source(s)"
+          + (f" -> {output_path}" if output_path else ""))
+    return result

--- a/cirada_senpy/science.py
+++ b/cirada_senpy/science.py
@@ -47,6 +47,29 @@ def spectral_index(flux_low, freq_low_mhz, flux_high, freq_high_mhz):
     return np.log10(flux_high / flux_low) / np.log10(freq_high_mhz / freq_low_mhz)
 
 
+def fit_spectral_index(freqs_mhz, fluxes):
+    """Power-law spectral index ``α`` (``S ∝ ν**α``) across two or more bands.
+
+    Fits ``log10(S) = α·log10(ν) + c`` by least squares over the positive,
+    finite points. Returns ``(alpha, alpha_err)``: for exactly two points the
+    index is exact and the error is NaN; with fewer than two usable points both
+    are NaN.
+    """
+    freqs = np.asarray(freqs_mhz, dtype=float)
+    fluxes = np.asarray(fluxes, dtype=float)
+    good = (freqs > 0) & (fluxes > 0) & np.isfinite(freqs) & np.isfinite(fluxes)
+    x, y = np.log10(freqs[good]), np.log10(fluxes[good])
+    if x.size < 2:
+        return float("nan"), float("nan")
+    if x.size == 2:
+        return float((y[1] - y[0]) / (x[1] - x[0])), float("nan")
+    design = np.vstack([x, np.ones_like(x)]).T
+    coeffs, *_ = np.linalg.lstsq(design, y, rcond=None)
+    residual_var = np.sum((y - design @ coeffs) ** 2) / (x.size - 2)
+    covariance = residual_var * np.linalg.inv(design.T @ design)
+    return float(coeffs[0]), float(np.sqrt(covariance[0, 0]))
+
+
 def spectral_index_map(low, freq_low_mhz, high, freq_high_mhz, threshold=0.05):
     """Per-pixel ``α`` between two co-gridded maps.
 

--- a/tests/unit/core/test_sed.py
+++ b/tests/unit/core/test_sed.py
@@ -1,0 +1,44 @@
+from cirada_senpy.core import spectral_index_from_catalog
+from unittest import TestCase
+
+import numpy as np
+import pandas as pd
+
+
+def make_catalog():
+    # Source A: steep (bright at 150, faint at 1400) + two VLASS tiles; one
+    # NVSS integrated is NaN to exercise the peak fallback; a DSS row that must
+    # be ignored (non-radio). Source B: flat.
+    return pd.DataFrame(
+        [
+            {"source": "A", "ra": 1.0, "dec": 2.0, "survey": "TGSS",  "peak": 100.0, "integrated": 100.0},
+            {"source": "A", "ra": 1.0, "dec": 2.0, "survey": "NVSS",  "peak": 10.0,  "integrated": np.nan},
+            {"source": "A", "ra": 1.0, "dec": 2.0, "survey": "VLASS", "peak": 6.0,   "integrated": 4.0},
+            {"source": "A", "ra": 1.0, "dec": 2.0, "survey": "VLASS", "peak": 7.0,   "integrated": 6.0},
+            {"source": "A", "ra": 1.0, "dec": 2.0, "survey": "DSS",   "peak": 5.0,   "integrated": np.nan},
+            {"source": "B", "ra": 3.0, "dec": 4.0, "survey": "TGSS",  "peak": 10.0,  "integrated": 10.0},
+            {"source": "B", "ra": 3.0, "dec": 4.0, "survey": "NVSS",  "peak": 10.0,  "integrated": 10.0},
+        ]
+    )
+
+
+class SpectralIndexFromCatalogTestCase(TestCase):
+    def test_per_source_fit(self):
+        result = spectral_index_from_catalog(make_catalog())
+        self.assertEqual(set(result["source"]), {"A", "B"})
+        a = result[result["source"] == "A"].iloc[0]
+        b = result[result["source"] == "B"].iloc[0]
+        # A is steep (negative); B is flat (~0).
+        self.assertLess(a["alpha"], -0.5)
+        self.assertAlmostEqual(b["alpha"], 0.0, places=6)
+
+    def test_ignores_non_radio_and_counts_bands(self):
+        result = spectral_index_from_catalog(make_catalog())
+        a = result[result["source"] == "A"].iloc[0]
+        # TGSS + NVSS + VLASS = 3 radio bands; DSS excluded.
+        self.assertEqual(a["n_bands"], 3)
+
+    def test_columns(self):
+        result = spectral_index_from_catalog(make_catalog())
+        for column in ("source", "ra", "dec", "n_bands", "alpha", "alpha_err"):
+            self.assertIn(column, result.columns)

--- a/tests/unit/science/test_science.py
+++ b/tests/unit/science/test_science.py
@@ -1,5 +1,6 @@
 from cirada_senpy.science import (
     SURVEY_FREQUENCY_MHZ,
+    fit_spectral_index,
     measure_cutout,
     peak_flux,
     spectral_index,
@@ -79,6 +80,30 @@ class FrequencyTableTestCase(TestCase):
         self.assertEqual(SURVEY_FREQUENCY_MHZ["TGSS"], 150.0)
         self.assertEqual(SURVEY_FREQUENCY_MHZ["NVSS"], 1400.0)
         self.assertEqual(SURVEY_FREQUENCY_MHZ["VLASS"], 3000.0)
+
+
+class FitSpectralIndexTestCase(TestCase):
+    def test_two_points_exact(self):
+        nu = [150.0, 1400.0]
+        flux = [150.0**-0.7, 1400.0**-0.7]
+        alpha, err = fit_spectral_index(nu, flux)
+        self.assertAlmostEqual(alpha, -0.7, places=6)
+        self.assertTrue(np.isnan(err))
+
+    def test_multi_band_fit_recovers_slope(self):
+        nu = np.array([150.0, 843.0, 1400.0, 3000.0])
+        flux = nu**-0.8
+        alpha, err = fit_spectral_index(nu, flux)
+        self.assertAlmostEqual(alpha, -0.8, places=4)
+        self.assertLess(err, 0.01)
+
+    def test_insufficient_points(self):
+        alpha, err = fit_spectral_index([1400.0], [10.0])
+        self.assertTrue(np.isnan(alpha) and np.isnan(err))
+
+    def test_ignores_nonpositive(self):
+        alpha, _ = fit_spectral_index([150.0, 1400.0, 3000.0], [100.0, 10.0, np.nan])
+        self.assertLess(alpha, 0)
 
 
 class MeasureCutoutTestCase(TestCase):


### PR DESCRIPTION
Folds the planned **Stage 2** (`senpy spectral-index`) and the **SED** idea into one feature — implemented as **pure post-processing over a `senpy measure` catalog** (no network, fully offline-testable).

```bash
senpy measure         targets.csv catalog.csv -s TGSS,NVSS,VLASS
senpy spectral-index  catalog.csv alpha.csv     # -> source, n_bands, alpha, alpha_err
```

### What it does
- `science.fit_spectral_index` — fits `S ∝ ν^α`: **exact** for two bands, **least-squares SED slope + uncertainty** for three or more.
- `core/sed.spectral_index_from_catalog` — per-source α over radio bands; uses integrated flux with peak fallback; collapses VLASS tiles to the brightest; ignores non-radio surveys.
- CLI `senpy spectral-index <catalog> <output> [-f integrated|peak]`.

### Why composable
Operating on the catalog (not re-fetching) means measure-once / analyse-many, and the whole thing is testable offline.

### Validation (end-to-end)
| source | α | type |
|---|---|---|
| 3C196 | −0.80 | steep ✓ (matches catalogued ≈−0.8) |
| 3C295 | −0.66 | steep ✓ |
| 3C48 | −0.64 | steep ✓ |
| 3C273 | −0.37 | flat ✓ |
| 3C84 | −0.30 | flat ✓ |

### Tests
7 new offline tests (46 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)